### PR TITLE
chore: inable send metadata

### DIFF
--- a/deepstream/app/deepstream.py
+++ b/deepstream/app/deepstream.py
@@ -308,11 +308,11 @@ class DynamicRTSPPipeline:
             frame_meta = pyds.NvDsFrameMeta.cast(l_frame.data)
 
             # Enqueue work
-            # self.process_queue.put({
-            #     "gst_buffer": gst_buffer,
-            #     "batch_id": frame_meta.batch_id,
-            #     "frame_meta": frame_meta
-            # })
+            self.process_queue.put({
+                "gst_buffer": gst_buffer,
+                "batch_id": frame_meta.batch_id,
+                "frame_meta": frame_meta
+            })
             # ----------------------------------------------------------------------
             # CALCULATE FPS
             # ----------------------------------------------------------------------


### PR DESCRIPTION
This pull request includes a small change in the `conv_pad_buffer_probe` method of the `deepstream/app/deepstream.py` file. The change re-enables the `process_queue.put` functionality by uncommenting and restoring the code block that enqueues work into the processing queue.