### PR TITLE
fat: add attempts for nvurisrcbin to try 10 after remove source

### DIFF
--- a/deepstream/app/source_bin_factory.py
+++ b/deepstream/app/source_bin_factory.py
@@ -1,5 +1,6 @@
 import gi
-gi.require_version("Gst", "1.0")
+gi.require_version('Gst', '1.0') 
+gi.require_version("GstRtspServer", "1.0")
 from gi.repository import Gst
 
 class SourceBinFactory:
@@ -43,13 +44,20 @@ class SourceBinFactory:
         return bin_
 
     def _create_nvurisrcbin(self, index: int, uri: str) -> Gst.Bin:
+        """ 
+            This GstBin is a GStreamer source bin. This bin is a wrapper over uridecodebin with additional 
+            functionality of the file looping, rtsp reconnection and smart record.
+        """
         bin_name = f"source-bin-{index}"
         bin_ = Gst.Bin.new(bin_name)
 
         nvurisrc = Gst.ElementFactory.make("nvurisrcbin", f"src-{index}")
         nvurisrc.set_property("uri", uri)
-        nvurisrc.set_property("rtsp-reconnect-interval", 1)
+        nvurisrc.set_property("rtsp-reconnect-interval", 5)
+        nvurisrc.set_property("rtsp-reconnect-attempts", 10)
         nvurisrc.set_property("select-rtp-protocol", 4)
+        nvurisrc.set_property("disable-audio", True)
+
 
         bin_.add(nvurisrc)
 


### PR DESCRIPTION
This pull request includes updates to the `deepstream` application to enhance functionality, improve maintainability, and address specific configuration needs. Key changes include adjustments to GStreamer initialization, modifications to pipeline behavior, and enhancements to error handling and source configuration.

### GStreamer Initialization Updates:
* Consolidated and moved `gi.require_version` calls for `Gst` and `GstRtspServer` to the top of `deepstream.py` and added them to `source_bin_factory.py` for consistency and proper initialization. [[1]](diffhunk://#diff-a2dc46be7479b2ba2fdea7b65a380b49f02fcc42f60ac6b3cd2c13b0325daeb6R3-R4) [[2]](diffhunk://#diff-4349d47116e8a7ce1c255928f0d4334eb41430421eb804f82585abde7e287e8cL2-R3)

### Pipeline Behavior Adjustments:
* Updated the `batched-push-timeout` property of `streammux` from `66700` to `67000` to fine-tune the frame rate to approximately 15 FPS.
* Commented out the addition of a probe on `streammux`'s static pad, possibly to disable certain downstream event handling temporarily.

### Error Handling Enhancements:
* Added a new handler in the `bus_call` method to process "attempt-exceeded" messages, logging the issue and notifying via the `notification_callback`. This also removes the offending stream source.

### Source Configuration Improvements:
* Enhanced `_create_nvurisrcbin` in `source_bin_factory.py` by:
  - Increasing `rtsp-reconnect-interval` from `1` to `5`.
  - Adding a new property `rtsp-reconnect-attempts` set to `10`.
  - Disabling audio with the `disable-audio` property.
  - Adding a docstring to clarify the purpose of the bin.