### PR TITLE
feat: add the option the diable segmetations in the osd output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ best.pt
 .venv/
 # Ignore Python cache files
 *.pyc
+deepstream/config/*.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     privileged: true
     environment:
       - DISPLAY=${DISPLAY}
+      - DEEPSTREAM_DISABLE_BOX_SEGMENTATION=1  # Disable bounding box segmentation
+      - DEEPSTREAM_IGNORE_CLASS_IDS_SEGMENTATION=0,4 # you can specify class IDs to ignore here in list example: 0,4
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ./:/deepstream_app


### PR DESCRIPTION
This PR adds two new runtime options in docker-compose  to control which instance-segmentation masks and boxes are displayed:

`DEEPSTREAM_DISABLE_BOX_SEGMENTATION` (bool)
When set to 1, hides all bounding-boxes (and labels) for segmentation results.

DEEPSTREAM_IGNORE_CLASS_IDS_SEGMENTATION (CSV list)
Specify class IDs whose masks, boxes, and labels should be completely hidden.

