### PR TITLE
send mask as np array

### DIFF
--- a/deepstream/app/deepstream.py
+++ b/deepstream/app/deepstream.py
@@ -464,8 +464,9 @@ class DynamicRTSPPipeline:
                 height = None
                 if maskparams is not None and maskparams.data:
                     mask_img = resize_mask(maskparams, math.floor(rectparams.width), math.floor(rectparams.height))
-                    mask_b64 = encode_mask_to_base64(mask_img)
+                    # mask_b64 = encode_mask_to_base64(mask_img)
                     mask_img = mask_img.astype(np.uint8)
+
 
                 if rectparams is not None:
                     left = rectparams.left
@@ -484,7 +485,7 @@ class DynamicRTSPPipeline:
                             "width": width,
                             "height": height
                         },
-                        "mask": mask_b64
+                        "mask": mask_img.tolist() if mask_img is not None else None,
                     })
                 
                 if objects.__len__() > 0:


### PR DESCRIPTION
This pull request modifies the `_processing_worker_loop` method in `deepstream/app/deepstream.py` to change how mask data is handled. The most important changes involve removing the base64 encoding of mask images and replacing it with a direct list representation for better compatibility and efficiency.

### Mask data handling improvements:
* Commented out the line that encoded mask images to base64 (`mask_b64 = encode_mask_to_base64(mask_img`) and replaced it with direct handling of the mask image as a NumPy array.
* Updated the mask field in the output dictionary to use `mask_img.tolist()` instead of the base64-encoded string, ensuring the mask is represented as a list of pixel values. If `mask_img` is `None`, the mask field is set to `None`.