### PR TITLE
bug: fix send mask to list insted of to byte

### DIFF
--- a/deepstream/app/deepstream.py
+++ b/deepstream/app/deepstream.py
@@ -460,6 +460,7 @@ class DynamicRTSPPipeline:
                     top = None
                     width = None
                     height = None
+                    mask_img = None
                     if maskparams is not None and maskparams.data:
                         mask_img = resize_mask(maskparams, math.floor(rectparams.width), math.floor(rectparams.height))
                         mask_img = mask_img.astype(np.uint8)
@@ -481,7 +482,7 @@ class DynamicRTSPPipeline:
                                 "width": width,
                                 "height": height
                             },
-                            "mask": mask_img.tobytes() if mask_img is not None else None,
+                            "mask": mask_img.tolist() if mask_img is not None else None,
                         })
                     l_obj = l_obj.next
                 


### PR DESCRIPTION
This pull request includes changes to the `_processing_worker_loop` method in `deepstream/app/deepstream.py` to improve how mask data is handled. The most important changes involve initializing the `mask_img` variable and modifying how the mask data is serialized.

Improvements to mask handling:

* [`deepstream/app/deepstream.py`](diffhunk://#diff-a2dc46be7479b2ba2fdea7b65a380b49f02fcc42f60ac6b3cd2c13b0325daeb6R463): Added initialization for the `mask_img` variable to ensure it is properly defined before use.
* [`deepstream/app/deepstream.py`](diffhunk://#diff-a2dc46be7479b2ba2fdea7b65a380b49f02fcc42f60ac6b3cd2c13b0325daeb6L484-R485): Changed the serialization of `mask_img` from `.tobytes()` to `.tolist()` to improve compatibility and readability of the data.