### PR TITLE
fat: convert RGBAto BGR frame on separte therad insted of main loop o…

### DIFF
--- a/deepstream/app/deepstream.py
+++ b/deepstream/app/deepstream.py
@@ -379,14 +379,13 @@ class DynamicRTSPPipeline:
 
             n_frame = pyds.get_nvds_buf_surface(hash(gst_buffer), frame_meta.batch_id)
             flat_frame = np.array(n_frame, copy=True)
-            frame_image = cv2.cvtColor(flat_frame, cv2.COLOR_RGBA2BGR)
-
+            
             # Enqueue work
             self.process_queue.put({
                 "gst_buffer": gst_buffer,
                 "batch_id": frame_meta.batch_id,
                 "frame_meta": frame_meta,
-                "frame_image": frame_image
+                "flat_frame": flat_frame
             })
 
             #? hide the mask data for objects with classes that are not in the range of interest
@@ -444,12 +443,13 @@ class DynamicRTSPPipeline:
             gst_buffer = task["gst_buffer"]
             batch_id = task["batch_id"]
             frame_meta = task["frame_meta"]
-            frame_image = task["frame_image"]
+            flat_frame = task["flat_frame"]
 
             try:
 
                 objects = []
                 l_obj = frame_meta.obj_meta_list
+                frame_image = cv2.cvtColor(flat_frame, cv2.COLOR_RGBA2BGR)
                 while l_obj is not None:
                     obj_meta = pyds.NvDsObjectMeta.cast(l_obj.data)
                     gie_unique_id = obj_meta.unique_component_id #? Get the unique ID of the inference component used in the configuration


### PR DESCRIPTION
This pull request refactors how image data is handled in the `deepstream.py` file, specifically by deferring the conversion of frame data from RGBA to BGR until it is needed in the processing worker loop. This change optimizes the pipeline by reducing unnecessary computations during the buffer probe stage.

### Refactoring image data handling:

* [`deepstream/app/deepstream.py`](diffhunk://#diff-a2dc46be7479b2ba2fdea7b65a380b49f02fcc42f60ac6b3cd2c13b0325daeb6L382-R388): In `conv_pad_buffer_probe`, replaced the `frame_image` key in the processing queue dictionary with `flat_frame`, which directly stores the raw RGBA frame data.
* [`deepstream/app/deepstream.py`](diffhunk://#diff-a2dc46be7479b2ba2fdea7b65a380b49f02fcc42f60ac6b3cd2c13b0325daeb6L447-R452): In `_processing_worker_loop`, moved the conversion of `flat_frame` to `frame_image` (BGR format) to this method, ensuring conversion happens only when required.…f gstreamer