### PR TITLE
fat: add create queue once

### DIFF
--- a/deepstream/app/deepstream.py
+++ b/deepstream/app/deepstream.py
@@ -174,6 +174,7 @@ class DynamicRTSPPipeline:
         src_bin.sync_state_with_parent()
         src_bin.set_state(Gst.State.PLAYING)
         self.urls_sources.append(uri)
+        self.rabbitmq_manager.create_queue(str(uuid))
 
         return uuid
 


### PR DESCRIPTION
This pull request introduces functionality to dynamically create RabbitMQ queues when adding new RTSP sources, enhancing the application's messaging capabilities. The changes primarily involve modifications to the `RabbitMQManager` class and its integration with the `DeepStream` application.

### Messaging enhancements:

* **Dynamic queue creation**: Added the `create_queue` method to the `RabbitMQManager` class, allowing queues to be declared with specific configurations such as TTL, max length, and overflow behavior. This method raises a `RuntimeError` if queue creation fails. (`deepstream/messaging/rabbitmq.py`, [deepstream/messaging/rabbitmq.pyL17-R28](diffhunk://#diff-f663b6764ce803de67c2329d1a5fba1c1c21e2c3ce9fce8c7a4a331ddb74b251L17-R28))
* **Queue creation during source addition**: Updated the `add_source` method in `DeepStream` to call `create_queue` for dynamically creating a RabbitMQ queue associated with each new RTSP source. (`deepstream/app/deepstream.py`, [deepstream/app/deepstream.pyR177](diffhunk://#diff-a2dc46be7479b2ba2fdea7b65a380b49f02fcc42f60ac6b3cd2c13b0325daeb6R177))