### PR TITLE
fix: fix mask issue, fix dell method to unlink and release all resource

### DIFF
--- a/backend/app/api/v1/endpoints.py
+++ b/backend/app/api/v1/endpoints.py
@@ -39,11 +39,11 @@ def add_stream(req: StreamRequest):
 
 
 @router.delete("/remove/{uuid}")
-def remove_stream(uuid: int):
-    # if index not in active_streams:
-    #     raise HTTPException(status_code=404, detail="Stream not found")
+def remove_stream(uuid: str):
+    if uuid not in active_streams:
+        raise HTTPException(status_code=404, detail="Stream not found")
     pipeline.remove_source(uuid)
-    # uri = active_streams.pop(index)
+    del active_streams[uuid]
     uri = "for now we do not return the uri"
     return {"message": "Stream removed", "uuid": uuid, "uri": uri}
 


### PR DESCRIPTION
This pull request introduces several updates to the stream management and pipeline handling logic, primarily focusing on improving resource cleanup, adding new pipeline elements, and ensuring proper handling of masks and performance data. Below is a summary of the most important changes:

### Stream Management Enhancements:
* Updated `remove_stream` in `endpoints.py` to check for the presence of a stream before attempting removal and properly delete the stream from `active_streams` using its `uuid`.

### Pipeline Resource Management:
* Enhanced the `remove_source` method in `deepstream.py` to ensure all pipeline elements are properly unlinked and removed, including releasing associated resources like `mux_pad` and `conv1`.
* Modified `_setup_output_branch` to use a dictionary for managing pipeline elements, improving clarity and enabling easier access to individual components.

### Mask Handling Improvements:
* Added `.copy()` when accessing mask data in `conv_pad_buffer_probe` and `resize_mask` to ensure data integrity and avoid side effects. [[1]](diffhunk://#diff-a2dc46be7479b2ba2fdea7b65a380b49f02fcc42f60ac6b3cd2c13b0325daeb6L480-R480) [[2]](diffhunk://#diff-a2dc46be7479b2ba2fdea7b65a380b49f02fcc42f60ac6b3cd2c13b0325daeb6L541-R541)

### Performance Data Management:
* Added cleanup of performance data (`all_stream_fps`) for `stream0` in the `start` method to prevent stale data from persisting across runs.